### PR TITLE
Properly escape url in the HTML generated in respnose to hURL requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed not escaping the URL string when generating HTML responses to hURL: requests.
+
 ## v3.0.0 (2022-11-25)
 
 ### Added

--- a/pygopherd/handlers/url.py
+++ b/pygopherd/handlers/url.py
@@ -1,3 +1,4 @@
+import html
 import re
 
 from pygopherd import gopherentry, handlers
@@ -42,6 +43,9 @@ class HTMLURLHandler(BaseHandler):
         url = self.selector[4:]  # Strip off URL:
         if self.selector[0] == "/":
             url = self.selector[5:]
+
+        url = html.escape(url)
+
         outdoc = "<HTML><HEAD>\n"
         outdoc += '<META HTTP-EQUIV="refresh" content="5;URL=%s">' % url
         outdoc += "</HEAD><BODY>\n"
@@ -77,7 +81,6 @@ class URLTypeRewriter(BaseHandler):
         )
 
     def gethandler(self):
-
         handlers.HandlerMultiplexer.init_default_handlers(self.config)
         handlerlist = [
             x for x in handlers.HandlerMultiplexer.handlers if x != URLTypeRewriter

--- a/tests/handlers/test_url.py
+++ b/tests/handlers/test_url.py
@@ -38,6 +38,30 @@ class TestHTMLURLHandler(unittest.TestCase):
             b'<A HREF="http://gopher.quux.org/">http://gopher.quux.org/</A>', out
         )
 
+    def test_handler_escape_urls(self):
+        """
+        URLs should be escaped in the generated HTML.
+        """
+        handler = HTMLURLHandler(
+            'URL:http://gopher.quux.org/"<script>',
+            "",
+            self.protocol,
+            self.config,
+            self.stat_result,
+            self.vfs,
+        )
+
+        entry = handler.getentry()
+        self.assertEqual(entry.mimetype, "text/html")
+        self.assertEqual(entry.type, "h")
+
+        wfile = io.BytesIO()
+        handler.write(wfile)
+
+        out = wfile.getvalue()
+        self.assertNotIn(b'http://gopher.quux.org/"<script>', out)
+        self.assertIn(b"http://gopher.quux.org/&quot;&lt;script&gt;", out)
+
 
 class TestURLTypeRewriterHandler(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #7 